### PR TITLE
Convert wind speed units from m/s to km/h

### DIFF
--- a/aemet/aemet.py
+++ b/aemet/aemet.py
@@ -653,6 +653,10 @@ class AemetWeather:
             if key in FIELD_MAPPINGS:
                 mapped_key = FIELD_MAPPINGS[key]
                 translated[mapped_key] = value
+        # Convert wind_speed and wind_max_speed from m/s to km/h        
+        for attr in MS_TO_KMH_ATTRS:
+            if attr in translated:
+                translated[attr] = round(translated[attr] * 3.6, 1) # m/s to km/h
         return translated
 
     def _clean_currently_data(self, raw_data):

--- a/aemet/const.py
+++ b/aemet/const.py
@@ -161,6 +161,8 @@ FIELD_MAPPINGS = dict(
     vv=ATTR_WEATHER_WIND_SPEED,
 )
 
+MS_TO_KMH_ATTRS = [ATTR_WEATHER_WIND_SPEED]
+
 DAILY_SENSORS_CONVERT = {
     # SENSOR:                        [jsonpath,               field]
     "precipitation probability":     ["probPrecipitacion[*]", "value"],


### PR DESCRIPTION
AEMET API returns both average wind speed (```vv```) and maximum wind speed (```vmax```) in meters per second, while Home Assistant [weather entity](https://developers.home-assistant.io/docs/core/entity/weather/) expects either km/h or mi/h for ```wind_speed```.

Since this entity does not check for the current ```unit_system``` and, to be honest, most people caring for Spanish weather are going to be using metric units anyway, I added the conversion from m/s to km/h in a similar fashion as seen [here](https://github.com/kalanda/homeassistant-aemet-sensor/blob/19b328b94f94b2daf402fa6b9d6d1aba9ddcb2b1/custom_components/aemet/AemetApi/__init__.py#L98).

A cleaner implementation would demand checking for the current ```unit_system``` in use and do the conversion for ```pressure```, ```visibility``` (not sure if this is something you get from AEMET anyway), and```wind_speed```. Since ```temperature_unit``` is a required field, I guess that Home Assistant handles the conversion of ```temperature``` itself.

**Important:** note that if the displayed ```wind_speed``` comes from forecast data, then it is in km/h and no conversion is needed! This might explain the confusion seen in https://github.com/outon/HomeAssistant-AEMET/issues/2. 

The ```weather_station``` I am pulling data from returns data for ```vv``` and ```vmax``` so I have not looked if this patch does perform the conversion when displaying ```wind_speed``` retrieved from forecast data. Just a heads up in case you want to include that logic in a better way than this ugly hack ;)

Cheers!
